### PR TITLE
필수 필드 누락 대응

### DIFF
--- a/gotcha/pipelines.py
+++ b/gotcha/pipelines.py
@@ -6,12 +6,24 @@
 # See: http://doc.scrapy.org/en/latest/topics/item-pipeline.html
 import logging
 from urlparse import urlparse
+
 from scrapy.exceptions import DropItem
+import MySQLdb
 
 logger = logging.getLogger('gotchaLogger')
 
-class GotchaPipeline(object):
+
+class NecessaryFieldEmptyDropPipeline(object):
     def process_item(self, item, spider):
+        if not item['title']:
+            raise DropItem("An article was dropped because 'title' field is empty (url: %s)" % item['url'])
+        if not item['content']:
+            raise DropItem("An article was dropped because 'content' field is empty (url: %s)" % item['url'])
+        if not item['writer']:
+            raise DropItem("An article was dropped because 'writer' field is empty (url: %s)" % item['url'])
+        if not item['created_at']:
+            raise DropItem("An article was dropped because 'created_at' field is empty (url: %s)" % item['url'])
+
         return item
 
 
@@ -24,9 +36,6 @@ class PotsuNetAdminArticleDropPipeline(object):
             raise DropItem("Admin's article in potsu.net was dropped (url: %s)" % item['url'])
 
         return item
-
-
-import MySQLdb
 
 
 class MySqlPipeline(object):

--- a/gotcha/settings.py
+++ b/gotcha/settings.py
@@ -62,7 +62,8 @@ CONCURRENT_REQUESTS_PER_IP = 16
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
-    'gotcha.pipelines.PotsuNetAdminArticleDropPipeline': 100,
+    'gotcha.pipelines.NecessaryFieldEmptyDropPipeline': 100,
+    'gotcha.pipelines.PotsuNetAdminArticleDropPipeline': 101,
     'gotcha.pipelines.MySqlPipeline': 900,
 }
 


### PR DESCRIPTION
크롤링으로 수집되는 필드 중에 필수 필드가 누락되면, 후처리 파이프라인으로 넘기지 않고 Drop 되도록 처리
title, content, writer, created_at 필드만 체크합니다. (일단, url, category 는 항상 받아올 수 있다는 가정하에 체크 로직에서 빼두었습니다.)

리뷰 부탁드려욤ㅎㅎ

fixed https://github.com/teamyy/gotcha/issues/11
