### PR TITLE
스크래피 설정 튜닝

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,5 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
-
+# scrapy module
+.scrapy

--- a/gotcha/settings.py
+++ b/gotcha/settings.py
@@ -85,8 +85,7 @@ MYSQL_USERNAME = 'gotcha'
 MYSQL_PASSWORD = 'gotchapw'
 MYSQL_SCHEMA = 'gotcha'
 
-# LOG_FILE = 'logs/gotcha.log'
-LOG_FILE = None
+LOG_FILE = 'logs/gotcha.log'
 LOG_ENABLED = True
 LOG_ENCODING = 'UTF-8'
 LOG_LEVEL = 'INFO'

--- a/gotcha/settings.py
+++ b/gotcha/settings.py
@@ -1,103 +1,91 @@
 # -*- coding: utf-8 -*-
 
-# Scrapy settings for gotcha project
-#
-# For simplicity, this file contains only settings considered important or
-# commonly used. You can find more settings consulting the documentation:
-#
-#     http://doc.scrapy.org/en/latest/topics/settings.html
-#     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
-#     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
-
 BOT_NAME = 'gotcha'
-
 SPIDER_MODULES = ['gotcha.spiders']
 NEWSPIDER_MODULE = 'gotcha.spiders'
-
-# Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = 'teamyy.gotcha (+https://github.com/teamyy/gotcha)'
 
-# Configure maximum concurrent requests performed by Scrapy (default: 16)
-CONCURRENT_REQUESTS = 32
-
-# Configure a delay for requests for the same website (default: 0)
-# See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
-# See also autothrottle settings and docs
-RANDOMIZE_DOWNLOAD_DELAY = True
-DOWNLOAD_DELAY = 3
-# The download delay setting will honor only one of:
-CONCURRENT_REQUESTS_PER_DOMAIN = 16
-CONCURRENT_REQUESTS_PER_IP = 16
-
-# Disable cookies (enabled by default)
-#COOKIES_ENABLED=False
-
-# Disable Telnet Console (enabled by default)
-#TELNETCONSOLE_ENABLED=False
-
-# Override the default request headers:
-#DEFAULT_REQUEST_HEADERS = {
-#   'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-#   'Accept-Language': 'en',
-#}
-
-# Enable or disable spider middlewares
-# See http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
-#SPIDER_MIDDLEWARES = {
-#    'gotcha.middlewares.MyCustomSpiderMiddleware': 543,
-#}
-
-# Enable or disable downloader middlewares
-# See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
-#DOWNLOADER_MIDDLEWARES = {
-#    'gotcha.middlewares.MyCustomDownloaderMiddleware': 543,
-#}
-
-# Enable or disable extensions
-# See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
-EXTENSIONS = {
-    'scrapy.extensions.logstats.LogStats': 100,
-    'scrapy.extensions.corestats.CoreStats': 200,
-    'scrapy.extensions.memusage.MemoryUsage': 300,
-    'scrapy.extensions.debug.StackTraceDump': 400,
+DEFAULT_REQUEST_HEADERS = {
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en,ko',
 }
 
-# Configure item pipelines
-# See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
+SPIDER_MIDDLEWARES = {
+    'scrapy.spidermiddlewares.httperror.HttpErrorMiddleware': 50,
+    'scrapy.spidermiddlewares.offsite.OffsiteMiddleware': 500,
+    'scrapy.spidermiddlewares.referer.RefererMiddleware': 700,
+    'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware': 800,
+    'scrapy.spidermiddlewares.depth.DepthMiddleware': 900,
+    # 'gotcha.middlewares.MyCustomSpiderMiddleware': 543,
+}
+
+DOWNLOADER_MIDDLEWARES = {
+    'scrapy.downloadermiddlewares.robotstxt.RobotsTxtMiddleware': 100,
+    'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware': 300,
+    'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware': 350,
+    'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware': 400,
+    'scrapy.downloadermiddlewares.retry.RetryMiddleware': 500,
+    'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware': 550,
+    'scrapy.downloadermiddlewares.ajaxcrawl.AjaxCrawlMiddleware': 560,
+    'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware': 580,
+    'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware': 590,
+    'scrapy.downloadermiddlewares.redirect.RedirectMiddleware': 600,
+    'scrapy.downloadermiddlewares.cookies.CookiesMiddleware': 700,
+    'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware': 750,
+    'scrapy.downloadermiddlewares.chunked.ChunkedTransferMiddleware': 830,
+    'scrapy.downloadermiddlewares.stats.DownloaderStats': 850,
+    'scrapy.downloadermiddlewares.httpcache.HttpCacheMiddleware': 900,
+    # 'gotcha.middlewares.MyCustomDownloaderMiddleware': 543,
+}
+
+EXTENSIONS = {
+    'scrapy.extensions.corestats.CoreStats': 100,
+    'scrapy.extensions.memusage.MemoryUsage': 200,
+    'scrapy.extensions.closespider.CloseSpider': 300,
+    'scrapy.extensions.logstats.LogStats': 400,
+    'scrapy.extensions.spiderstate.SpiderState': 500,
+    'scrapy.extensions.throttle.AutoThrottle': 600,
+    'scrapy.extensions.debug.StackTraceDump': 700,
+}
+
 ITEM_PIPELINES = {
     'gotcha.pipelines.NecessaryFieldEmptyDropPipeline': 100,
-    'gotcha.pipelines.PotsuNetAdminArticleDropPipeline': 101,
-    'gotcha.pipelines.MySqlPipeline': 900,
+    'gotcha.pipelines.PotsuNetAdminArticleDropPipeline': 200,
+    'gotcha.pipelines.MySqlPipeline': 300,
 }
 
-# Enable and configure the AutoThrottle extension (disabled by default)
-# See http://doc.scrapy.org/en/latest/topics/autothrottle.html
-# NOTE: AutoThrottle will honour the standard settings for concurrency and delay
+RANDOMIZE_DOWNLOAD_DELAY = True
+DOWNLOAD_DELAY = 3
+
+CONCURRENT_REQUESTS = 32
+CONCURRENT_REQUESTS_PER_DOMAIN = 8
+CONCURRENT_ITEMS = 500
+
+COOKIES_ENABLED = False
+
+TELNETCONSOLE_ENABLED = False
+
 AUTOTHROTTLE_ENABLED = True
-# The initial download delay
 AUTOTHROTTLE_START_DELAY = 5
-# The maximum download delay to be set in case of high latencies
 AUTOTHROTTLE_MAX_DELAY = 60
-# Enable showing throttling stats for every response received:
 AUTOTHROTTLE_DEBUG = False
 
-# Enable and configure HTTP caching (disabled by default)
-# See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
-#HTTPCACHE_ENABLED=True
-#HTTPCACHE_EXPIRATION_SECS=0
-#HTTPCACHE_DIR='httpcache'
-#HTTPCACHE_IGNORE_HTTP_CODES=[]
-#HTTPCACHE_STORAGE='scrapy.extensions.httpcache.FilesystemCacheStorage'
+HTTPCACHE_ENABLED = True
+HTTPCACHE_EXPIRATION_SECS = 600
+HTTPCACHE_DIR = ''
+HTTPCACHE_IGNORE_HTTP_CODES = []
+HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.LeveldbCacheStorage'
+HTTPCACHE_IGNORE_MISSING = False
+HTTPCACHE_POLICY = 'scrapy.extensions.httpcache.RFC2616Policy'
+HTTPCACHE_DBM_MODULE = 'leveldb'
 
-# Database connection info
 MYSQL_HOST = 'apolloners.goanygate.com'
 MYSQL_PORT = 3306
 MYSQL_USERNAME = 'gotcha'
 MYSQL_PASSWORD = 'gotchapw'
 MYSQL_SCHEMA = 'gotcha'
 
-# Log settings
-# LOG_FILE = 'logs/gotcha.log' # Uncomment this after development
+# LOG_FILE = 'logs/gotcha.log'
 LOG_FILE = None
 LOG_ENABLED = True
 LOG_ENCODING = 'UTF-8'
@@ -106,10 +94,24 @@ LOG_FORMAT = '%(asctime)s [%(name)s] %(levelname)s: %(message)s'
 LOG_DATEFORMAT = '%Y-%m-%d %H:%M:%S'
 LOG_STDOUT = False
 
-# Memory usage settings
 MEMUSAGE_ENABLED = True
 MEMUSAGE_LIMIT_MB = 1024
 MEMUSAGE_WARNING_MB = 0
 MEMUSAGE_NOTIFY_MAIL = None
 MEMUSAGE_REPORT = False
 MEMUSAGE_CHECK_INTERVAL_SECONDS = 60
+
+DEPTH_LIMIT = 0
+DEPTH_PRIORITY = 1
+DEPTH_STATS = True
+
+URLLENGTH_LIMIT = 240
+
+ROBOTSTXT_OBEY = True
+
+REDIRECT_ENABLED = False
+REDIRECT_MAX_TIMES = 0
+
+RETRY_ENABLED = True
+RETRY_TIMES = 3
+

--- a/gotcha/spiders/HumorUnivSpider.py
+++ b/gotcha/spiders/HumorUnivSpider.py
@@ -16,7 +16,7 @@ class HumorUnivSpider(CrawlSpider):
     ]
 
     rules = (
-        Rule(LinkExtractor(allow=('/board/humor/read\.html\?.*table=pds.*', )), callback='parse_pds'),
+        Rule(LinkExtractor(allow=('/board/humor/read\.html\?.*table=pds.*', )), callback='parse_pds', follow=True),
     )
 
     def parse_pds(self, response):

--- a/gotcha/spiders/PotsuNetSpider.py
+++ b/gotcha/spiders/PotsuNetSpider.py
@@ -16,7 +16,7 @@ class PotsuNetSpider(CrawlSpider):
     ]
 
     rules = (
-        Rule(LinkExtractor(allow=('/index\.php\?.*mid=humor.*&.*document_srl=[0-9]+.*', )), callback='parse_humor'),
+        Rule(LinkExtractor(allow=('/index\.php\?.*mid=humor.*&.*document_srl=[0-9]+.*', )), callback='parse_humor', follow=True),
     )
 
     def parse_humor(self, response):

--- a/gotcha/spiders/PpomppuSpider.py
+++ b/gotcha/spiders/PpomppuSpider.py
@@ -16,7 +16,7 @@ class PpomppuSpider(CrawlSpider):
     ]
 
     rules = (
-        Rule(LinkExtractor(allow=('/zboard/view\.php\?.*id=humor.*&.*no=[0-9]+.*', )), callback='parse_humor'),
+        Rule(LinkExtractor(allow=('/zboard/view\.php\?.*id=humor.*&.*no=[0-9]+.*', )), callback='parse_humor', follow=True),
     )
 
     def parse_humor(self, response):

--- a/gotcha/spiders/TodayHumorSpider.py
+++ b/gotcha/spiders/TodayHumorSpider.py
@@ -16,7 +16,7 @@ class TodayHumorSpider(CrawlSpider):
     ]
 
     rules = (
-        Rule(LinkExtractor(allow=('/board/view\.php\?.*table=humordata.*', ), deny=('/board/view\.php\?.*no_tag=1.*', )), callback='parse_humor'),
+        Rule(LinkExtractor(allow=('/board/view\.php\?.*table=humordata.*', ), deny=('/board/view\.php\?.*no_tag=1.*', )), callback='parse_humor', follow=True),
     )
 
     def parse_humor(self, response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 MySQL-python>=1.2.5
 Scrapy>=1.0.5
 SQLAlchemy>=1.0.12
+leveldb>=0.193


### PR DESCRIPTION
- HTTP 캐시 활성화 (LevelDb 메모리 DB 사용)
- 링크 Follow enabled & Max link depth 설정
- 로봇룰 준수하도록 설정
- 리다이렉션 비활성화 & 요청 실패 시, 3회 재시도 설정
- URL 최대 길이 240 바이트 제한 (디비 저장소와 일치)

Fixes https://github.com/teamyy/gotcha/issues/26
